### PR TITLE
Fix gas parsing and varint error message

### DIFF
--- a/neocliapi/getapplicationlog.go
+++ b/neocliapi/getapplicationlog.go
@@ -3,8 +3,8 @@ package neocliapi
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"github.com/terender/neo-go-sdk/neotransaction"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -56,7 +56,7 @@ func GetApplicationLog(url string, txid string) ([]Argument, int64, error) {
 	gas := int64(0)
 
 	gasconsumed, ok := result[`gas_consumed`].(string)
-	if !ok {
+	if ok {
 		v, err := strconv.ParseFloat(gasconsumed, 10)
 		if err == nil {
 			gas = int64(v * float64(neotransaction.TxOutputValueBase))

--- a/neocliapi/invokescript.go
+++ b/neocliapi/invokescript.go
@@ -4,9 +4,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"github.com/terender/neo-go-sdk/neotransaction"
 	"github.com/terender/neo-go-sdk/neoutils"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -117,7 +117,7 @@ func Invoke(url string, scriptHashString string, params []interface{}) ([]Argume
 	gas := int64(0)
 
 	gasconsumed, ok := result[`gas_consumed`].(string)
-	if !ok {
+	if ok {
 		v, err := strconv.ParseFloat(gasconsumed, 10)
 		if err == nil {
 			gas = int64(v * float64(neotransaction.TxOutputValueBase))
@@ -185,7 +185,7 @@ func InvokeScript(url string, script []byte) ([]Argument, int64, error) {
 	gas := int64(0)
 
 	gasconsumed, ok := result[`gas_consumed`].(string)
-	if !ok {
+	if ok {
 		v, err := strconv.ParseFloat(gasconsumed, 10)
 		if err == nil {
 			gas = int64(v * float64(neotransaction.TxOutputValueBase))

--- a/neoutils/varint.go
+++ b/neoutils/varint.go
@@ -78,7 +78,7 @@ func ParseVarInt(bytes []byte) (VarInt, error) {
 	}
 
 	if len(bytes) < 9 {
-		return ret, errors.New(fmt.Sprint("ParseVarInt: input bytes starts with 0xfe but length", len(bytes)))
+		return ret, errors.New(fmt.Sprint("ParseVarInt: input bytes starts with 0xff but length", len(bytes)))
 	}
 	ret.Value = binary.LittleEndian.Uint64(bytes[1:])
 	return ret, nil


### PR DESCRIPTION
## Summary
- fix incorrect check when parsing `gas_consumed`
- update error message in `ParseVarInt`

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_683fb0259c1c8328bf3ca7a6ce57ddf9